### PR TITLE
fix nested value in defaults getting override

### DIFF
--- a/packages/inertia-svelte/package.json
+++ b/packages/inertia-svelte/package.json
@@ -29,6 +29,7 @@
     "svelte": "^3.20.0"
   },
   "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0"
   }
 }

--- a/packages/inertia-svelte/src/useForm.js
+++ b/packages/inertia-svelte/src/useForm.js
@@ -1,4 +1,5 @@
 import isEqual from 'lodash.isequal'
+import cloneDeep from 'lodash.clonedeep'
 import { writable } from 'svelte/store'
 import { Inertia } from '@inertiajs/inertia'
 
@@ -6,7 +7,7 @@ function useForm(...args) {
   const rememberKey = typeof args[0] === 'string' ? args[0] : null
   const data = (typeof args[0] === 'string' ? args[1] : args[0]) || {}
   const restored = rememberKey ? Inertia.restore(rememberKey) : null
-  let defaults = data
+  let defaults = cloneDeep(data)
   let cancelToken = null
   let recentlySuccessfulTimeoutId = null
   let transform = data => data
@@ -22,7 +23,7 @@ function useForm(...args) {
     processing: false,
     setStore(key, value) {
       store.update(store => {
-        return Object.assign({}, store, typeof key === 'string' ? {[key]: value} : key)
+        return Object.assign({}, store, typeof key === 'string' ? {[key]: cloneDeep(value)} : cloneDeep(key))
       })
     },
     data() {


### PR DESCRIPTION
The nested value in defaults will be override when the data update because of the sharing same instance with data.
```js
let form = useForm({
    name: '',
    address: {
        line1: "",
        line2: "",
        city: "",
        state: "",
        postcode: "",
    }
});
console.log($form.address === $form.defaults.address); // showing they are same instance
$form.address.city = "Kuala Lumpur";
console.log($form.defaults.address.city); // => "Kuala Lumpur", while the expected value is empty string
console.log($form.isDirty); // => false, because $form.address and $form.defaults.address are same value so its not "dirty"
```